### PR TITLE
添加蘑菇2翻译。优化Otakuroom和Rampage的文本翻译，修复死宅房ZM关倒计时问题以及添加Rampage外场倒计时

### DIFF
--- a/ze/ze_forsaken_temple.json
+++ b/ze/ze_forsaken_temple.json
@@ -2,7 +2,7 @@
   {
     "original": "< ze_Forsaken_Temple >",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "< 遗忘神殿 >",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -11,7 +11,7 @@
   {
     "original": "< Map by Brian >",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "< 地图由 Brian 制作 >",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -20,7 +20,7 @@
   {
     "original": "** WARM UP - 60 SEC **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 热身 - 60 秒 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 60,
@@ -29,7 +29,7 @@
   {
     "original": "< CS2 Port by @Seth >",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "< CS2 移植 @Seth >",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -38,7 +38,7 @@
   {
     "original": "** WARM UP - 50 SEC **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 热身 - 50 秒 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 50,
@@ -47,7 +47,7 @@
   {
     "original": "** WARM UP - 40 SEC **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 热身 - 40 秒 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 40,
@@ -56,7 +56,7 @@
   {
     "original": "** TIP: one player must touch the closed door to trigger **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 提示: 必须要有一个人贴门才能触发 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -65,7 +65,7 @@
   {
     "original": "** WARM UP - 30 SEC **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 热身 - 30 秒 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -74,16 +74,16 @@
   {
     "original": "** STAGE 1: Underground **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 第一关: 地下遗迹 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 1,
-    "enable_timer": 1
+    "timer_num": 0,
+    "enable_timer": 0
   },
   {
     "original": "** ADMIN SELECTED STAGE 3 **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 调关房：关卡变更为 第三关 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 3,
@@ -92,7 +92,7 @@
   {
     "original": "** TIP: most zombie teleports are quick so do not overdefend! **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 提示：僵尸传送很快，所以别死断! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -101,7 +101,7 @@
   {
     "original": "** WARM UP - 20 SEC **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 热身 - 20 秒 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 20,
@@ -110,7 +110,7 @@
   {
     "original": "** TIP: search for key items when the console tells you to do so **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 提示：地图消息会告诉你搜索关键物品",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -119,7 +119,7 @@
   {
     "original": "** WARM UP - 10 SEC **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 热身 - 10 秒 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 10,
@@ -128,7 +128,7 @@
   {
     "original": "** Left fence is breaking in 30s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 左侧栅栏 30 秒后开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -137,7 +137,7 @@
   {
     "original": "** Door is opening in 40s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 门 40 秒后开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 40,
@@ -146,7 +146,7 @@
   {
     "original": "** Find and press TWO buttons **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 找到并触发两个按钮 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -155,25 +155,25 @@
   {
     "original": "** Button 1 pressed **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 按钮 1 已触发 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 1,
-    "enable_timer": 1
+    "timer_num": 0,
+    "enable_timer": 0
   },
   {
     "original": "** Button 2 pressed **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 按钮 2 已触发 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 2,
-    "enable_timer": 1
+    "timer_num": 0,
+    "enable_timer": 0
   },
   {
     "original": "** Nicely done **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 干得漂亮 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -182,7 +182,7 @@
   {
     "original": "** Door is opening in 20s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 门在 20 秒后开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 20,
@@ -191,7 +191,7 @@
   {
     "original": "** Door is opening in 35s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 门在 35 秒后开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 35,
@@ -200,7 +200,7 @@
   {
     "original": "** It's seems the door is locked **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 这个门似乎被锁住了 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -209,7 +209,7 @@
   {
     "original": "** Hint: key item owner must touch the locked door **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 提示：钥匙所有者必须贴门才能触发 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -218,7 +218,7 @@
   {
     "original": "** Use the key to unlock it **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 用钥匙开门 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -227,7 +227,7 @@
   {
     "original": "** Nicely done! The door is going to unlock! **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 干得漂亮! 门很快会解锁了! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -236,7 +236,7 @@
   {
     "original": "** JUMP! **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 跳上去! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -245,7 +245,7 @@
   {
     "original": "** Door is opening in 25s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 门在 25 秒后开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 25,
@@ -254,7 +254,7 @@
   {
     "original": "** Door is closing in 10s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 门在 10 秒后开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 10,
@@ -263,7 +263,7 @@
   {
     "original": "** Divine Tears - crouch **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 神圣之泪 - 快蹲下 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -272,7 +272,7 @@
   {
     "original": "** Vampire - stop shooting **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 吸血状态 - 停止射击 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -281,7 +281,7 @@
   {
     "original": "** Ricochet - jump **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 弹射 - 跳起来! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -290,7 +290,7 @@
   {
     "original": "** You are too slow! Boss enrage soon! **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 打得太慢了! Boss要进入狂怒状态了! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -299,7 +299,7 @@
   {
     "original": "** Boss defeated **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** Boss 已被击败 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -308,7 +308,7 @@
   {
     "original": "** Retreat! **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 原路返回! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -317,7 +317,7 @@
   {
     "original": "** Door is opening in 30s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 门在 30 秒后开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -326,7 +326,7 @@
   {
     "original": "** Air-strike is incoming **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 空袭即将来临 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -335,7 +335,7 @@
   {
     "original": "** Survive 60s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 生存 60 秒 *",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 60,
@@ -344,7 +344,7 @@
   {
     "original": "** Kill all weakened zombies **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 杀死全部残血僵尸 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -353,7 +353,7 @@
   {
     "original": "** Hurry up! 15 seconds left **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 搞快点啊! 就剩 15 秒了 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 15,
@@ -362,7 +362,7 @@
   {
     "original": "** ADMIN SELECTED STAGE 2 **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 调关房：关卡变更为 第二关 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 2,
@@ -371,16 +371,16 @@
   {
     "original": "** STAGE 2: Investigation **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 第二关 调查 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 2,
-    "enable_timer": 1
+    "timer_num": 0,
+    "enable_timer": 0
   },
   {
     "original": "** Right fence is breaking in 30s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 右侧栅栏 30 秒后开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -389,7 +389,7 @@
   {
     "original": "** Gate is opening in 25s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 大门 25 秒后开启",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 25,
@@ -398,7 +398,7 @@
   {
     "original": "** It seems.. left flame, right fruit.. ? **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "**似乎... 左边是火焰，右边是...水果???",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -407,7 +407,7 @@
   {
     "original": "** Door is opening in 10s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 门 10 秒后开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 10,
@@ -416,7 +416,7 @@
   {
     "original": "** Find two key items!! **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 找到两件关键物品!! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -425,7 +425,7 @@
   {
     "original": "** Nicely done! You got the correct combination! **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 干得漂亮! 你们找到了正确组合 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -434,7 +434,7 @@
   {
     "original": "** Pit is opening in 20s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 大坑 20 秒后开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 20,
@@ -443,7 +443,7 @@
   {
     "original": "** Defend 20s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 防守 20 秒 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 20,
@@ -452,16 +452,16 @@
   {
     "original": "** Boss enrage in THREE minutes **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** Boss 会在180秒后进入狂暴",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 180,
+    "enable_timer": 1
   },
   {
     "original": "** Tumult - use heal **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 混沌攻击 - 快使用治疗 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -470,7 +470,7 @@
   {
     "original": "** Servant - defend zombies from now **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 奴仆召唤 - 守尸笼! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -479,7 +479,7 @@
   {
     "original": "** Weight of the Land - move away **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 大地之力 - 远离它! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -488,7 +488,7 @@
   {
     "original": "** Boss defeated! RUN! **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** Boss 已被击败! 快跑! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -497,7 +497,7 @@
   {
     "original": "** Gate is opening in 40s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 大门 40 秒后开启",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 40,
@@ -506,7 +506,7 @@
   {
     "original": "** Rock is breaking in 10s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 石头 10 秒后清理干净 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 10,
@@ -515,7 +515,7 @@
   {
     "original": "** Press TWO buttons on both sides **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 按下两边的按钮 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -524,7 +524,7 @@
   {
     "original": "** Vortex **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 旋风 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -533,7 +533,7 @@
   {
     "original": "** Weight of the Land **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 大地之力 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -542,7 +542,7 @@
   {
     "original": "** Sink **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 下沉 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -551,7 +551,7 @@
   {
     "original": "** Door is opening in 40s *",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 门在 40 秒后开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 40,
@@ -560,7 +560,7 @@
   {
     "original": "** Door is opening in 15s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 门在 15 秒后开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 15,
@@ -569,7 +569,7 @@
   {
     "original": "** Helicopter is leaving 10s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 直升机 10 秒后离开 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 10,
@@ -578,7 +578,7 @@
   {
     "original": "** MOVING ON TO STAGE 3 **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 移动至 第三关 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 3,
@@ -587,7 +587,7 @@
   {
     "original": "** STAGE 3: Escape **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 第三关: 逃出生天 *",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 3,
@@ -596,7 +596,7 @@
   {
     "original": "** Find another key item!! **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 找到另一件关键物品!! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -605,7 +605,7 @@
   {
     "original": "** Temple door is opening soon **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 神庙大门很快开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -614,7 +614,7 @@
   {
     "original": "** You must defend until the door opens **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 你必须守到门开 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -623,7 +623,7 @@
   {
     "original": "** Fixing the door. Keep defending! **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 正在修复大门! 拖住他们! *",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -632,7 +632,7 @@
   {
     "original": "** Someone got baited... **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 有人上当了... **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -641,7 +641,7 @@
   {
     "original": "** The door will open soon **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 门很快开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -650,7 +650,7 @@
   {
     "original": "** Hang on... Keep defending! **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 坚持住... 继续防守! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -659,7 +659,7 @@
   {
     "original": "** Just a little bit more... **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 就差最后一点... **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -668,7 +668,7 @@
   {
     "original": "** Maze exit is opening in 35s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "**迷宫出口 25 秒后开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 35,
@@ -677,7 +677,7 @@
   {
     "original": "** Elevator is leaving in 20s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 电梯 25 秒后离开 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 20,
@@ -686,7 +686,7 @@
   {
     "original": "** Zombie items are temporary disabled **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 僵尸神器暂时禁用 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -695,7 +695,7 @@
   {
     "original": "** Dancing Claw **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 舞动之爪 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -704,7 +704,7 @@
   {
     "original": "** Divine Tears **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 神圣之泪 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -713,7 +713,7 @@
   {
     "original": "** Swallow **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 淹没一切**",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -722,7 +722,7 @@
   {
     "original": "** Vampire **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 吸血状态 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -731,7 +731,7 @@
   {
     "original": "** Force **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 自然之力 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -740,16 +740,16 @@
   {
     "original": "** MOVING ON TO STAGE 2 **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 移动至 第二关 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 2,
-    "enable_timer": 1
+    "timer_num": 0,
+    "enable_timer": 10
   },
   {
     "original": "** Zombie items can be used again **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 僵尸神器现在可以使用了 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -758,7 +758,7 @@
   {
     "original": "** Maze exit is opening in 10s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 迷宫出口 10 秒后开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 10,
@@ -767,7 +767,7 @@
   {
     "original": "** Exit door is opening in 10s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 出口大门 10 秒后开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 10,
@@ -776,7 +776,7 @@
   {
     "original": "** DODGE THE LASERS AND KILL THE BOSS **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 跳刀并击败Boss **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -785,7 +785,7 @@
   {
     "original": "** Landslide - avoid red platform **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 山崩地裂 - 避开红色平台 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -794,7 +794,7 @@
   {
     "original": "** Incorrect combination! The pit will open SLOWER!! **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 错误排序! 大坑将会延缓开启!! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -803,7 +803,7 @@
   {
     "original": "** Pit is opening in 40s **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 大坑 40 秒后开启 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 40,
@@ -812,7 +812,7 @@
   {
     "original": "** HE IS DEAD! RUN FOR YOUR LYFE! **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 他死了! 快跑!!! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -821,7 +821,7 @@
   {
     "original": "** GO LEFT **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 左边是路 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -830,7 +830,7 @@
   {
     "original": "** KILL IT BEFORE IT KILLS YOU **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 击败他!要不然都得死! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -839,7 +839,7 @@
   {
     "original": "** You have failed to escape from the temple **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 你失败了!你无法逃离神庙 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -848,7 +848,7 @@
   {
     "original": "** You must kill the temple creature before it kills you **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 杀了神庙造物! 要不然你要被他干死了! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -857,7 +857,7 @@
   {
     "original": "** GET TO THE HELICOPTER NOW! **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 快上飞机! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -866,7 +866,7 @@
   {
     "original": "** YOU HAVE BEATEN THE MAP **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 你们是冠军! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -875,7 +875,7 @@
   {
     "original": "** ZM MODE **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** ZM 关 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -884,7 +884,7 @@
   {
     "original": "** Do not follow ZE path! Survive until nuke! **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 不用沿着ZE的路线! 活到核爆就行! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -893,7 +893,7 @@
   {
     "original": "** 270 SECONDS LEFT **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 生存 270 秒 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 270,
@@ -902,7 +902,7 @@
   {
     "original": "儚い欠片　舞い散る 虛幻的碎片\\在空中飛舞散落",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "虛幻的碎片\\在空中飛舞散落",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -911,7 +911,7 @@
   {
     "original": "その光　全て照らし\\那道光芒　照亮一切",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "その光　全て照らし\\那道光芒　照亮一切",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -920,7 +920,7 @@
   {
     "original": "導き逢う...\\引導著相遇...",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "導き逢う...\\引導著相遇...",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -929,7 +929,7 @@
   {
     "original": "** 240 SECONDS LEFT **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 生存 240 秒 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 240,
@@ -938,7 +938,7 @@
   {
     "original": "壊れてゆく　感情の果て\\崩毀的思念的盡頭",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "壊れてゆく　感情の果て\\崩毀的思念的盡頭",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -947,7 +947,7 @@
   {
     "original": "いつかの夢を捨てるよ\\曾經追求的夢境寧願全捨棄",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "いつかの夢を捨てるよ\\曾經追求的夢境寧願全捨棄",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -956,7 +956,7 @@
   {
     "original": "正解の無い　選択肢しか\\不存在正確的　選項路線分歧",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "正解の無い　選択肢しか\\不存在正確的　選項路線分歧",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -965,7 +965,7 @@
   {
     "original": "僕に殘されていないなら...\\看不清向何處前進迷離與嘆息...",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "僕に殘されていないなら...\\看不清向何處前進迷離與嘆息...",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -974,7 +974,7 @@
   {
     "original": "fripSide - Hesitation Snow",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "正在播放 fripSide - Hesitation Snow",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -983,7 +983,7 @@
   {
     "original": "季節はすでに暗く冷たく\\已經是冰冷幽暗的季節",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "季節はすでに暗く冷たく\\已經是冰冷幽暗的季節",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -992,7 +992,7 @@
   {
     "original": "溫もり求めた心\\渴求溫存的心卻少了勇氣",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "溫もり求めた心\\渴求溫存的心卻少了勇氣",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1001,7 +1001,7 @@
   {
     "original": "君は現れ　時間は止まり\\因為你出現時機　讓時間隨之而停",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "君は現れ　時間は止まり\\因為你出現時機　讓時間隨之而停",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1010,7 +1010,7 @@
   {
     "original": "物語が始まった...\\然而故事物語已悄然進行...",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "物語が始まった...\\然而故事物語已悄然進行...",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1019,7 +1019,7 @@
   {
     "original": "真実に近づけば\\一旦與事實真相更接近",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "真実に近づけば\\一旦與事實真相更接近",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1028,7 +1028,7 @@
   {
     "original": "君を守ることでしか\\我就只能默默無語守護你",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "君を守ることでしか\\我就只能默默無語守護你",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1037,7 +1037,7 @@
   {
     "original": "想い示せないまま\\無法明示這份愛戀之情",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "想い示せないまま\\無法明示這份愛戀之情",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1046,7 +1046,7 @@
   {
     "original": "冷たい無情が絡まる\\冰冷的無情便糾葛一起不清",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "冷たい無情が絡まる\\冰冷的無情便糾葛一起不清",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1055,7 +1055,7 @@
   {
     "original": "** 180 SECONDS LEFT **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 生存 100 秒 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 180,
@@ -1064,7 +1064,7 @@
   {
     "original": "墮ちていった　純粋な瞳に\\不自覺望向你　那純粹的眼睛",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "墮ちていった　純粋な瞳に\\不自覺望向你　那純粹的眼睛",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1073,7 +1073,7 @@
   {
     "original": "映る何もかも　歪んでく...\\瞳孔裡歪斜與扭曲一切被照映...",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "映る何もかも　歪んでく...\\瞳孔裡歪斜與扭曲一切被照映...",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1082,7 +1082,7 @@
   {
     "original": "耳元囁く君の聲さえ\\就連耳邊輕響起你對我細語喃呢",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "耳元囁く君の聲さえ\\就連耳邊輕響起你對我細語喃呢",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1091,7 +1091,7 @@
   {
     "original": "悔しくなって　傷をつけても\\後悔已經來不及　早已弄傷了身體",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "悔しくなって　傷をつけても\\後悔已經來不及　早已弄傷了身體",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1100,7 +1100,7 @@
   {
     "original": "その意味は何処にも無い\\再怎麼撐下去也已無意義",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "その意味は何処にも無い\\再怎麼撐下去也已無意義",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1109,7 +1109,7 @@
   {
     "original": "永遠を求めれば\\倘若追尋永恆",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "永遠を求めれば\\倘若追尋永恆",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1118,7 +1118,7 @@
   {
     "original": "君の心に近づく?\\是否就能步步接近你的心?",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "君の心に近づく?\\是否就能步步接近你的心?",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1127,7 +1127,7 @@
   {
     "original": "終わりのない理想が\\停不下的理想永無止境",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "終わりのない理想が\\停不下的理想永無止境",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1136,7 +1136,7 @@
   {
     "original": "殘酷な痛みを誘う\\現實卻殘酷到只能嘆息哭泣",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "殘酷な痛みを誘う\\現實卻殘酷到只能嘆息哭泣",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1145,7 +1145,7 @@
   {
     "original": "誰一人も　責められずに\\誰也無須在意　更無任何罪刑",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "誰一人も　責められずに\\誰也無須在意　更無任何罪刑",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1154,7 +1154,7 @@
   {
     "original": "** 120 SECONDS LEFT **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 生存 120 秒 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 120,
@@ -1163,7 +1163,7 @@
   {
     "original": "悪いのは　自分だったと\\犯下錯誤一方正是我自己",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "悪いのは　自分だったと\\犯下錯誤一方正是我自己",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1172,7 +1172,7 @@
   {
     "original": "想い込んで　耐え切れなくて\\被壓迫的思緒　容忍不了罪名",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "想い込んで　耐え切れなくて\\被壓迫的思緒　容忍不了罪名",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1181,7 +1181,7 @@
   {
     "original": "僕は生まれ変わる　心ごと...\\盡全力脫胎新生命洗滌淨心靈...",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "僕は生まれ変わる　心ごと...\\盡全力脫胎新生命洗滌淨心靈...",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1190,7 +1190,7 @@
   {
     "original": "取り戻した　記憶さえも\\就算是取回　曾經擁有記憶",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "取り戻した　記憶さえも\\就算是取回　曾經擁有記憶",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1199,7 +1199,7 @@
   {
     "original": "どこか　信じられなくて\\有些是連自己都無法相信",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "どこか　信じられなくて\\有些是連自己都無法相信",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1208,7 +1208,7 @@
   {
     "original": "世界中が　色を亡くしてく...\\世界曾有美麗　顏色卻已消失殆盡...",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "世界中が　色を亡くしてく...\\世界曾有美麗　顏色卻已消失殆盡...",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1217,7 +1217,7 @@
   {
     "original": "もう　気づいてた\\已經　不可能迴避...",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "もう　気づいてた\\已經　不可能迴避...",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1226,7 +1226,7 @@
   {
     "original": "狂っている　定義が今\\瘋狂如何定義　失常錯亂如今",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "狂っている　定義が今\\瘋狂如何定義　失常錯亂如今",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1235,7 +1235,7 @@
   {
     "original": "** 60 SECONDS LEFT **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 生存 60 秒 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 60,
@@ -1244,7 +1244,7 @@
   {
     "original": "調和の糸　手繰り寄せ\\拉起調和絲系墜落到淵底",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "調和の糸　手繰り寄せ\\拉起調和絲系墜落到淵底",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1253,7 +1253,7 @@
   {
     "original": "僕を見透かして... 操ってた\\被看清沒有了底細我已任你命令",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "僕を見透かして... 操ってた\\被看清沒有了底細我已任你命令",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1262,7 +1262,7 @@
   {
     "original": "** 30 SECONDS LEFT **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 生存 30 秒 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -1271,7 +1271,7 @@
   {
     "original": "儚い欠片　舞い散る\\虛幻的碎片　在空中飛舞散落",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "儚い欠片　舞い散る\\虛幻的碎片　在空中飛舞散落",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1280,7 +1280,7 @@
   {
     "original": "** 15 SECONDS LEFT **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 生存 15 秒 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 15,
@@ -1289,7 +1289,7 @@
   {
     "original": "** 10 SECONDS LEFT **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 生存 10 秒 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 10,
@@ -1298,7 +1298,7 @@
   {
     "original": "** 5 SECONDS LEFT **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "<<< 5 >>>",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 5,
@@ -1307,7 +1307,7 @@
   {
     "original": "** Nuke is incoming **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "核弹来袭",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1316,7 +1316,7 @@
   {
     "original": "** Admin room is located behind the spawn **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "调关房已定位至出生点后",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,

--- a/ze/ze_obj_rampage_v1_2.json
+++ b/ze/ze_obj_rampage_v1_2.json
@@ -20,7 +20,7 @@
   {
     "original": "Special thanks to Zombieden for testing and people who guiding me on anything",
     "en_trans": "",
-    "zh_trans": "特别感谢：Zombieden提供测试服以及指导我制作这张地图的人们",
+    "zh_trans": "特别感谢僵尸乐园提供的测试服以及指导我制作这张图的所有人!",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -434,16 +434,16 @@
   {
     "original": "C4 has been planted",
     "en_trans": "",
-    "zh_trans": "炸弹已经安放。92秒（1分32秒）后爆炸",
+    "zh_trans": "炸弹已经安放。92秒后爆炸",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 92,
+    "enable_timer": 1
   },
   {
     "original": "Rampage Level",
     "en_trans": "",
-    "zh_trans": "等级:Rampage",
+    "zh_trans": "冲突等级升级!",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,

--- a/ze/ze_otakuroom_pt.json
+++ b/ze/ze_otakuroom_pt.json
@@ -14,8 +14,8 @@
     "zh_trans": "**原地图 : kz_otakuroom_v3 , 由 GemaYue 制作**",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 3,
-    "enable_timer": 1
+    "timer_num": 0,
+    "enable_timer": 0
   },
   {
     "original": "**Map by Tenshi**",
@@ -344,28 +344,28 @@
   {
     "original": "**Nuke in 3 mins**",
     "en_trans": "",
-    "zh_trans": "**3分钟后核爆**",
+    "zh_trans": "**180秒后核爆**",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 3,
+    "timer_num": 180,
     "enable_timer": 1
   },
   {
     "original": "**Nuke in 2 mins**",
     "en_trans": "",
-    "zh_trans": "**2分钟后核爆**",
+    "zh_trans": "**120秒后核爆**",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 2,
+    "timer_num": 120,
     "enable_timer": 1
   },
   {
     "original": "**Nuke in 1 min**",
     "en_trans": "",
-    "zh_trans": "**1分钟后核爆**",
+    "zh_trans": "**60秒后核爆**",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 1,
+    "timer_num": 60,
     "enable_timer": 1
   },
   {

--- a/ze/ze_shroomforest2_p.json
+++ b/ze/ze_shroomforest2_p.json
@@ -2,7 +2,7 @@
   {
     "original": ">> Map by Taskuvaras <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 地图制作 Taskuvaras && 翻译：Asuka Langley <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -11,7 +11,7 @@
   {
     "original": ">> Finished by Moltard <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 由 Moltard 完成 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -20,7 +20,7 @@
   {
     "original": ">> WARMUP ROUND <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 热身回 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -29,7 +29,7 @@
   {
     "original": ">> 40 SECONDS LEFT <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 还剩 40 秒<<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 40,
@@ -38,7 +38,7 @@
   {
     "original": ">> LEVEL: RAVINE <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">>关卡：山涧<<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -47,7 +47,7 @@
   {
     "original": "*** LEAF LEAVING IN 20 SECONDS ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 树叶 20 秒后离开 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 20,
@@ -56,7 +56,7 @@
   {
     "original": ">> PLAYER HAS PICKED UP WATER <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 玩家拾取了 水 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -65,7 +65,7 @@
   {
     "original": ">> PLAYER HAS PICKED UP ICE <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 玩家拾取了 冰 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -74,7 +74,7 @@
   {
     "original": "*** HOLD FOR 30 SECONDS ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 坚持 30 秒 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -83,7 +83,7 @@
   {
     "original": "*** 5 MORE SECONDS ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 还有 5 秒 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 5,
@@ -92,7 +92,7 @@
   {
     "original": "*** RUUUN! ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 足包! ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -101,7 +101,7 @@
   {
     "original": ">> PLAYER HAS PICKED UP WIND <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 玩家拾取了 风 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -110,7 +110,7 @@
   {
     "original": ">> PLAYER HAS PICKED UP FIRE <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 玩家拾取了 火 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -119,7 +119,7 @@
   {
     "original": "*** DOOR IS OPEN! RUUUN! ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 门开了! 跑路!**",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -128,7 +128,7 @@
   {
     "original": ">> ITS THE GROKE SHOOT IT !!!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 莫兰正在向我们攻击! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -137,16 +137,16 @@
   {
     "original": ">> PLAYER HAS PICKED UP 6 MINES <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 玩家拾取了 地雷 （可用 6 次）",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 0,
     "enable_timer": 1
   },
   {
     "original": ">> ALL 6 MINES USED <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 全部地雷已使用 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 6,
@@ -155,7 +155,7 @@
   {
     "original": ">> THE GROKE IS DEAD <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 莫兰死了 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -164,7 +164,7 @@
   {
     "original": ">> ESCAPE BY THE LADDER <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 从梯子那爬出去! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -173,7 +173,7 @@
   {
     "original": "*** FLY LEAVING IN 15 SECONDS ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 蝴蝶在 15 秒后离开***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 15,
@@ -182,7 +182,7 @@
   {
     "original": ">> LEVEL COMPLETED !!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 关卡完成 !!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -191,7 +191,7 @@
   {
     "original": ">> LEVEL: TV <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 关卡: 电视 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -200,7 +200,7 @@
   {
     "original": ">> PLAYER HAS PICKED UP GRAVITY <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 玩家拾取了 重力 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -209,7 +209,7 @@
   {
     "original": ">> PLAYER HAS PICKED UP HEAL <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 玩家拾取了 治疗 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -218,7 +218,7 @@
   {
     "original": "*** FALL BACK !!! ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 该走了 !!! ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -227,7 +227,7 @@
   {
     "original": "*** ELEVATOR OPENING IN 20 SECONDS ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 电梯门 20 秒后开启 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 20,
@@ -236,7 +236,7 @@
   {
     "original": "*** ELEVATOR LEAVING IN 10 SECONDS ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 电梯门 10 秒后开启 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 10,
@@ -245,7 +245,7 @@
   {
     "original": "*** FAN STOPPING IN 30 SECONDS ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 风扇 30 秒后停止 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -254,7 +254,7 @@
   {
     "original": "*** FALL BACK ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 该走了! ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -263,7 +263,7 @@
   {
     "original": ">> BREAK THE HEART OF THE TV <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 破坏电视的电源! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -272,7 +272,7 @@
   {
     "original": ">> THE TV HEART IS DESTROYED <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 电视电源已被破坏 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -281,7 +281,7 @@
   {
     "original": ">> THE BUILDING WILL BLOW UP <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 这个地方要炸啦! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -290,7 +290,7 @@
   {
     "original": "*** WEB LEAVING IN 20 SECONDS ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 蜘蛛网 20 秒后离开 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 20,
@@ -299,7 +299,7 @@
   {
     "original": ">> ESCAPE BY THE WEB <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 离开蜘蛛网 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -308,7 +308,7 @@
   {
     "original": ">> LEVEL COMPLETED!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 关卡完成!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -317,7 +317,7 @@
   {
     "original": ">> LEVEL: HEAVEN <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 关卡：天堂 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -326,7 +326,7 @@
   {
     "original": "*** CLOUD LEAVING IN 20 SECONDS ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 云在 20 秒后离开 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 20,
@@ -335,7 +335,7 @@
   {
     "original": "*** HEAVEN GATES OPENING IN 25 SECONDS ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 天堂之门 25 秒后开启 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 25,
@@ -344,7 +344,7 @@
   {
     "original": "*** GATE OPENING IN 25 SECONDS ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 大门 25 秒后开启 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 25,
@@ -353,7 +353,7 @@
   {
     "original": "*** DOORS OPENING IN 30 SECONDS ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 门 30 秒后开启 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -362,7 +362,7 @@
   {
     "original": ">> OH NO!! ITS GOD <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 我去! 是上帝 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -371,7 +371,7 @@
   {
     "original": ">> PLAYER HAS PICKED UP EARTH <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 玩家拾取了 土 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -380,7 +380,7 @@
   {
     "original": ">> PLAYER HAS PICKED UP UNLIMITED AMMO <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 玩家拾取了 弹药 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -389,7 +389,7 @@
   {
     "original": ">> GOD HAS BEEN DEFEATED !!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 上帝被击败了 !!!",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -398,7 +398,7 @@
   {
     "original": ">> RUN TO SAFETY <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 快跑到安全的地方 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -407,7 +407,7 @@
   {
     "original": "*** BUTTERFLY LEAVING IN 15 SECONDS ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 蝴蝶 15 秒后离开 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 15,
@@ -416,7 +416,7 @@
   {
     "original": ">> EXTREME MODE ADDED <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> EX难度 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -425,7 +425,7 @@
   {
     "original": ">> ZOMBIE SHROOM HAS BEEN PICKED UP <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 马勃菌 已拾起 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -434,7 +434,7 @@
   {
     "original": "*** FLY LEAVING IN 20 SECONDS ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 蝴蝶 20 秒后离开 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 20,
@@ -443,7 +443,7 @@
   {
     "original": ">> OH NO!! ITS FAT SPIDER <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 蛙趣! 是大蜘蛛<<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -452,7 +452,7 @@
   {
     "original": ">> FAT SPIDER IS DEAD <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 大蜘蛛 死了~ <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -461,7 +461,7 @@
   {
     "original": "*** FLY LEAVING IN 30 SECONDS ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 蝴蝶 30 秒后离开 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -470,7 +470,7 @@
   {
     "original": ">> ZOMBIE CLOUD HAS BEEN PICKED UP <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 雷云 已拾起 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -479,7 +479,7 @@
   {
     "original": "*** GATE OPENING IN 30 SECONDS ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 大门 30 秒后开启 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -488,7 +488,7 @@
   {
     "original": ">> FALL BACK <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 撤退! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -497,7 +497,7 @@
   {
     "original": ">> OH NO!! ITS FALLEN ANGEL <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 不好!! 是堕天使 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -506,7 +506,7 @@
   {
     "original": ">> FALLEN ANGEL HAS BEEN DEFEATED !!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 堕天使 已被击败 !!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -515,7 +515,7 @@
   {
     "original": ">> LET THE ANGELS ESCAPE FIRST <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 得让天使们先走!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -524,7 +524,7 @@
   {
     "original": ">> CONTINUE TO DEFEND <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 继续防守! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -533,7 +533,7 @@
   {
     "original": ">> THE LAST ANGEL IS OUT <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 最后一个天使已离开 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -542,7 +542,7 @@
   {
     "original": "*** BUTTERFLY LEAVING IN 30 SECONDS ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 蝴蝶 30 秒后离开 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -551,7 +551,7 @@
   {
     "original": "*** BUTTERFLY IS DEAD !!!! DEFEND LONGER !!!! ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 蝴蝶死了 !!!! 得再守一会 !!!! ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -560,7 +560,7 @@
   {
     "original": ">> THE ANGELS GOT THE RESCUE PLANK BACK <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 天使们带着救援板来了！K <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -569,7 +569,7 @@
   {
     "original": ">> FALL BACK !!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 撤退 !!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -578,7 +578,7 @@
   {
     "original": ">> THEY WILL TELEPORT US OUT <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 他们会带我们离开! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -587,7 +587,7 @@
   {
     "original": ">> IS THIS SATAN WORK.... <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 这是撒旦干的吗.... <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -596,7 +596,7 @@
   {
     "original": ">> TELEPORTING ZOMBIES <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 僵尸传送 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -605,7 +605,7 @@
   {
     "original": ">> WE HAVE TO ESCAPE THIS PLACE <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 我们得逃离这个地方 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -614,7 +614,7 @@
   {
     "original": ">> CLOUD LEAVING IN 40 SECONDS <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 云在 40 秒后升起 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 40,
@@ -623,7 +623,7 @@
   {
     "original": ">> LEVEL: THE END <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 关卡: 结束了？ <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -632,7 +632,7 @@
   {
     "original": ">> THE GRID IS CLOSED <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 栅栏已关闭 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -641,7 +641,7 @@
   {
     "original": ">> DEFEND LONGER <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 再守一会 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -650,7 +650,7 @@
   {
     "original": ">> A CLOUD IS COMING <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 云正在赶来 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -659,7 +659,7 @@
   {
     "original": ">> CLOUD LEAVING IN 10 SECONDS <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 云 10 秒后离开 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 10,
@@ -668,7 +668,7 @@
   {
     "original": ">> IT'S SATAN WITH THE ANGELS !!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 这是怎么回事? 撒旦绑架了天使们?!! <<<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -677,7 +677,7 @@
   {
     "original": ">> ... HE IS GONE <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> ... 他跑了 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -686,7 +686,7 @@
   {
     "original": ">> HOLD ZOMBIES UNTIL THE BUTTERFLY COME <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 守到蝴蝶到来 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -695,7 +695,7 @@
   {
     "original": ">> BUTTERFLY IS HERE !!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 蝴蝶来了 !!!",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -704,7 +704,7 @@
   {
     "original": ">> RESCUE BUTTERFLY LEAVING IN 20 SECONDS <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 救援蝴蝶 20 秒后离开 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 20,
@@ -713,7 +713,7 @@
   {
     "original": ">> ZOMBIE ABOARD !! YOU FAILED !! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 僵尸上来了 !! 你失败了 !! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -722,7 +722,7 @@
   {
     "original": "*** WHERE DID SATAN GO... ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 撒旦跑去哪了... ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -731,7 +731,7 @@
   {
     "original": "*** THE DRAGON IS BACK FROM HELL !!! ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 冥界之龙从地狱回来了 !!! ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -740,7 +740,7 @@
   {
     "original": "*** WE HAVE TO KILL HIM AS FAST AS POSSIBLE ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 我们必须尽快杀死它! ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -749,7 +749,7 @@
   {
     "original": "*** NADES DO MORE DAMAGE !!! ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 手雷能造成更多伤害 !!! ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -758,7 +758,7 @@
   {
     "original": ">> THE DRAGON HAS BEEN DEFEATED !!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 冥界之龙被击败了 !!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -767,7 +767,7 @@
   {
     "original": "*** GOOD JOB TEAM !!! ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 干得漂亮各位 !!! ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -776,7 +776,7 @@
   {
     "original": "*** .... WHAT IS HAPPENING ?? ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 不对 .... 这是怎么回事 ?? ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -785,7 +785,7 @@
   {
     "original": ">> IT'S SATAN AGAIN !!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 怎么是撒旦 !!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -794,7 +794,7 @@
   {
     "original": ">> SHOOT HIM WE NEED TO SAVE THE ANGELS !!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 向他开枪 !!! 我们得拯救那些天使!!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -803,7 +803,7 @@
   {
     "original": ">> NADE DOES MORE DAMAGE <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 手雷能造成更多伤害 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -812,7 +812,7 @@
   {
     "original": ">> SATAN IS HURT !!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 撒旦 受伤了 !!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -821,7 +821,7 @@
   {
     "original": ">> ESCAPE VIA THE PORTAL !!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 通过传送门离开 !!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -830,7 +830,7 @@
   {
     "original": ">> DONT LET ZOMBIES GET IN !!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 别让僵尸们进来 !!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -839,7 +839,7 @@
   {
     "original": ">> PORTAL CLOSING IN 10 SECONDS !!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 传送门 10 秒后关闭 !!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 10,
@@ -848,7 +848,7 @@
   {
     "original": ">> PORTAL CLOSING IN 5 SECONDS !!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 传送门 5 秒后关闭 !!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 5,
@@ -857,7 +857,7 @@
   {
     "original": ">> PORTAL IS CLOSING !!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 传送门正在关闭 !!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -866,7 +866,7 @@
   {
     "original": ">> SATAN IS FINALLY DEFEATED !!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 撒旦终于被击败了 !!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -875,7 +875,7 @@
   {
     "original": ">> We finally did it <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 我们做到了！ <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -884,7 +884,7 @@
   {
     "original": ">> But the world won't be the same anymore... <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 但世界已不再是以前的世界了... <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -893,7 +893,7 @@
   {
     "original": ">> We have to go back where everything started <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 我们必须回到一切的起点 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -902,7 +902,7 @@
   {
     "original": ">> We are getting closer to our destination <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 我们正在接近我们的目的地 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -911,7 +911,7 @@
   {
     "original": ">> Back then we left our village without any defense <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 但是我们离开村庄的话，这意味着无人防守我们的村庄 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -920,7 +920,7 @@
   {
     "original": ">> Let's hope nothing bad happened <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 哎，听天由命吧 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -929,7 +929,7 @@
   {
     "original": ">> We are starting our descent <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 我们得开始下降了 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -938,7 +938,7 @@
   {
     "original": ">> This is really bad... <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 这真的太糟糕了... <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -947,7 +947,7 @@
   {
     "original": ">> Satan's power didn't even spare our old village ! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 撒旦的力量甚至影响了我们的旧村庄 ! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -956,7 +956,7 @@
   {
     "original": ">> We have to save everyone ! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 我们必须拯救所有人 ! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -965,7 +965,7 @@
   {
     "original": ">> Congratulations ! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 恭喜你 ! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -974,7 +974,7 @@
   {
     "original": ">> You beat the map ! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 全图通关 ! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -983,7 +983,7 @@
   {
     "original": ">> Play ShroomForest3 to continue the adventure <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 蘑菇三将继续我们的冒险 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -992,7 +992,7 @@
   {
     "original": ">> TV HEART IS COLLAPSING KEEP SHOOTING !!!!!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 电视电源正在崩溃 !!!!!! 继续射击 !!!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1001,7 +1001,7 @@
   {
     "original": ">> LEVEL: ZM <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 关卡: ZM <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1010,7 +1010,7 @@
   {
     "original": ">> SURVIVE 180 SECONDS IN THE SPAWN AND TV AREA <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 在出生点或者电视区域生存 180 秒 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 180,
@@ -1019,7 +1019,7 @@
   {
     "original": ">> FIND THE TELEPORTER TO LEVEL ROOM <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 找到调关房的传送门 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1028,7 +1028,7 @@
   {
     "original": ">> PLAYER HAS CHOSEN: THE END <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 玩家已选择关卡: 结束了？ <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -1037,7 +1037,7 @@
   {
     "original": ">> 150 SECONDS LEFT <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 还剩 150 秒 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 150,
@@ -1046,7 +1046,7 @@
   {
     "original": ">> 120 SECONDS LEFT <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 还剩 120 秒 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 120,
@@ -1055,7 +1055,7 @@
   {
     "original": ">> 90 SECONDS LEFT <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 还剩 90 秒 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 90,
@@ -1064,7 +1064,7 @@
   {
     "original": ">> 70 SECONDS LEFT <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 还剩 70 秒 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 70,
@@ -1073,7 +1073,7 @@
   {
     "original": ">> 50 SECONDS LEFT <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 还剩 50 秒 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 50,
@@ -1082,7 +1082,7 @@
   {
     "original": ">> 30 SECONDS LEFT <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 还剩 30 秒 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -1091,7 +1091,7 @@
   {
     "original": ">> 20 SECONDS LEFT <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 还剩 20 秒 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 20,
@@ -1100,7 +1100,7 @@
   {
     "original": ">> 10 SECONDS LEFT <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 还剩 10 秒 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 10,
@@ -1109,7 +1109,7 @@
   {
     "original": ">> 5 SECONDS LEFT <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 还剩 5 秒 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 5,

--- a/ze/ze_tesv_skyrim_p.json
+++ b/ze/ze_tesv_skyrim_p.json
@@ -2,7 +2,7 @@
   {
     "original": ">> WARMUP ROUND <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 热身回 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -11,7 +11,7 @@
   {
     "original": "*** Map By P'a'ss and Kim ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 地图由 P'a'ss 和 Kim 制作 && 翻译: Asuka Langley***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -20,7 +20,7 @@
   {
     "original": ">>> After winning a round you will get 100 points which equals with 1 level <<<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">>> 当你取得回合胜利时，你会获得100点分数，这相当于一级 <<<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -29,7 +29,7 @@
   {
     "original": ">>> Level 1 item requires 100 points Level 2 item requires 200 points and so on. <<<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">>> 一级神器要求100点积分，二级神器要求200点积分，以此类推。不能越级拿神器，懂了吗？ <<<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -38,7 +38,7 @@
   {
     "original": ">>> When round starts you have small amount of time to pick an item before the zombies spawn <<<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">>> 回合开始后，在僵尸爆你菊之前你只有一点时间去拿皮肤/神器 <<<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -47,7 +47,7 @@
   {
     "original": ">>> AFTER PICKING UP AN ITEM YOU CAN USE THEIR ATTACKS WITH EITHER LEFT OR RIGHT MOUSE CLICK <<<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">>> 在拾取神器后，你可以通过鼠标左键或者右键进行攻击  <<<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -56,7 +56,7 @@
   {
     "original": ">>> Shooting the Zombie items in the head will push them back! <<<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">>> 射击僵尸皮肤的头部可以击退他们! <<<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -65,7 +65,7 @@
   {
     "original": ">>> ONLY 1 OF EACH HUMAN ITEMS CAN BE TAKEN AT ONCE <<<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">>> 每种人类神器/皮肤只能拾取一次 <<<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 1,
@@ -74,7 +74,7 @@
   {
     "original": ">> Stage 1 Helgen <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 第一幕 半途遭伏急须遁，仓皇逃奔海尔根 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 1,
@@ -83,7 +83,7 @@
   {
     "original": ">> City gate closes in 50 seconds <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 城门 50 秒后关闭 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 50,
@@ -92,7 +92,7 @@
   {
     "original": ">> Run for the helgen keep NOW! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 尽快前往海尔根城! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -101,7 +101,7 @@
   {
     "original": ">> The dragon is fleeing! Run to the Helgen keep! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 龙逃了! 必须尽快前往海尔根城 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -110,7 +110,7 @@
   {
     "original": ">> Defend until someone gets the key from the other room! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 防守至有人找到钥匙! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -119,7 +119,7 @@
   {
     "original": "*** We got the key! ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 我们找到钥匙了! ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -128,7 +128,7 @@
   {
     "original": "*** Door should open soon! ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 门很快打开! ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -137,7 +137,7 @@
   {
     "original": "*** Door opens in 25 seconds! ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 门在 25 秒后开启! ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 25,
@@ -146,7 +146,7 @@
   {
     "original": "*** FALL BACK ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 撤退 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -155,7 +155,7 @@
   {
     "original": "*** Door opens in 30 seconds ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 门在 30 秒后开启 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -164,7 +164,7 @@
   {
     "original": ">> Defend the bridge don't let the zombies on the other side! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 守住这座桥!别把僵尸放过来! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -173,7 +173,7 @@
   {
     "original": ">> Fall back Now!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 现在快撤退!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -182,7 +182,7 @@
   {
     "original": "*** Stage Completed ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 第一幕 完成 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -191,7 +191,7 @@
   {
     "original": ">> Stage 2 Whiterun <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 第二幕 龙袭迫切十万急，速报雪漫城领主<<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 2,
@@ -200,7 +200,7 @@
   {
     "original": ">> City door opens in 35 seconds! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 城门 35 秒后开启! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 35,
@@ -209,7 +209,7 @@
   {
     "original": ">> We need to inform the Jarl of Whiterun that the dragons are attacking! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 我们必须把龙袭的消息告知雪漫城领主!",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -218,7 +218,7 @@
   {
     "original": ">> We need to hold the Plains District for 45 seconds HOLD THEM BACK! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 我们得守住平原区 45 秒。守住兄弟们 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 45,
@@ -227,7 +227,7 @@
   {
     "original": ">> Fall Back Now! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 现在撤退! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -236,7 +236,7 @@
   {
     "original": ">> Hold here for 30 seconds! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 坚守 30 秒! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -245,7 +245,7 @@
   {
     "original": ">> Hold them back for 25 more seconds! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 拖住他们 25 秒! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 25,
@@ -254,7 +254,7 @@
   {
     "original": ">> Run for the bridge of Dragons Reach!! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 快前往龙脊桥!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -263,7 +263,7 @@
   {
     "original": ">> Defend the bridge until door opens! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 守住这座桥! 直至大门开启! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -272,7 +272,7 @@
   {
     "original": ">> Dragon has been spotted outside Whiterun! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 龙出现在了雪漫城外! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -281,7 +281,7 @@
   {
     "original": ">> Exit through the secret door! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 从密道出去! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -290,7 +290,7 @@
   {
     "original": ">> IT'S A DRAGON! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 是龙!! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -299,7 +299,7 @@
   {
     "original": ">> SHOOT IT! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 把它干了! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -308,7 +308,7 @@
   {
     "original": ">> The dragon is fleeing! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 龙跑了! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -317,7 +317,7 @@
   {
     "original": ">> Run towards the tower now! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 现在快跑向那座塔! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -326,7 +326,7 @@
   {
     "original": ">> Door Closes in 25 seconds <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 门在 25 秒后关闭 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 25,
@@ -335,7 +335,7 @@
   {
     "original": ">> Keep Defending! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 坚持住! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -344,7 +344,7 @@
   {
     "original": ">> Door Closes in 15 seconds <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 门在 15 秒后关闭 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 15,
@@ -353,7 +353,7 @@
   {
     "original": ">> Door Closes in 5 seconds <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 门在 5 秒后关闭 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 5,
@@ -362,7 +362,7 @@
   {
     "original": ">> Stage Completed! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 第二幕 完成 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -371,7 +371,7 @@
   {
     "original": ">> Stage 3 Road To Dwemer Ruins <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 第三幕 奔赴废墟路漫漫，急盼良策破龙威 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 3,
@@ -380,7 +380,7 @@
   {
     "original": "*** Hold the cave for 30 seconds ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 守住这个洞穴 30 秒 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -389,7 +389,7 @@
   {
     "original": "*** Hold the bridges for 30 seconds ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 守住这座桥 30 秒 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -398,7 +398,7 @@
   {
     "original": "*** There should be a switch for that door somewhere! ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 开关应该被锻摩尔人藏在什么地方了，找找! ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -407,7 +407,7 @@
   {
     "original": "*** You have found the switch! ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 找到开关了! ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -416,7 +416,7 @@
   {
     "original": "*** Door will open in 25 seconds ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 门在 25 秒后开启 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 25,
@@ -425,7 +425,7 @@
   {
     "original": "*** Seems like the lever is broken ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 拉杆看上去坏了 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -434,7 +434,7 @@
   {
     "original": "*** Find a way to fix it! ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 想办法修好它! ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -443,7 +443,7 @@
   {
     "original": "*** Hold for 25 seconds ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 守住 25 秒 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 25,
@@ -452,7 +452,7 @@
   {
     "original": "*** Door will open in 30 seconds ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 门在 30 秒后开启 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -461,7 +461,7 @@
   {
     "original": "*** Hold for 45 seconds OR find a way to make it open faster ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 守 45 秒，或者想办法让这门开得快些 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 45,
@@ -470,7 +470,7 @@
   {
     "original": "*** Good job ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 干得漂亮 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -479,7 +479,7 @@
   {
     "original": "*** The doors will now open a bit faster! ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 门现在开得快些了! ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -488,7 +488,7 @@
   {
     "original": "*** Lever has been pulled! ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 拉杆已拉动! ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -497,7 +497,7 @@
   {
     "original": "*** Hold for just 25 seconds more! ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 就守住 25 秒! 坚持住 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 25,
@@ -506,7 +506,7 @@
   {
     "original": "*** Stage completed! ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "***第三幕 完成 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -515,7 +515,7 @@
   {
     "original": ">> Stage 4 Dwemer ruins <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 第四幕 废墟觅得破局法，上古卷轴克巨龙 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 4,
@@ -524,7 +524,7 @@
   {
     "original": ">>> Doors open in 25 seconds <<<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">>> 门在 25 秒后开启 <<<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 25,
@@ -533,7 +533,7 @@
   {
     "original": ">> Door Opens in 45 seconds <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">>> 门在 45 秒后开启 <<<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 45,
@@ -542,7 +542,7 @@
   {
     "original": ">> Go Downstairs to the Treasure room and take the Elder Scroll! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 下楼，去藏宝室找到上古卷轴! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -551,7 +551,7 @@
   {
     "original": ">> Find a way to open the Door! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 找到开门的法子了! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -560,7 +560,7 @@
   {
     "original": ">> Lever has been pressed! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 拉杆已拉下! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -569,7 +569,7 @@
   {
     "original": ">> Door Opens In 20 Seconds! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 门在 20 后开启! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 20,
@@ -578,7 +578,7 @@
   {
     "original": ">> Elevator leaves in 30 seconds! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 电梯 30 秒后离开! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 30,
@@ -587,7 +587,7 @@
   {
     "original": ">> Elevator leaves in 10 seconds! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 电梯 10 秒后离开! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 10,
@@ -596,7 +596,7 @@
   {
     "original": ">> Elevator leaves in 5 seconds! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 电梯 5 秒后离开! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 5,
@@ -605,7 +605,7 @@
   {
     "original": ">> Elevator is leaving! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 电梯正在离开! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -614,7 +614,7 @@
   {
     "original": ">> Elevator leaves in 20 seconds! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 电梯 20 秒后离开! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 20,
@@ -623,7 +623,7 @@
   {
     "original": ">> Stage 5 Sovngarde <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 第五幕 背水一战，与龙决死 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 5,
@@ -632,7 +632,7 @@
   {
     "original": ">> City door opens in 25 seconds! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 城门 25 秒后开启! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 25,
@@ -641,7 +641,7 @@
   {
     "original": ">> HOLD THEM BACK! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 拖住他们! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -650,7 +650,7 @@
   {
     "original": ">> We need to hold the Plains District for 40 seconds HOLD THEM BACK! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 我们需要守住平原区 40 秒! 拖住他们! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 40,
@@ -659,7 +659,7 @@
   {
     "original": ">> We need to get away from these dragons! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 我们得远离这些龙! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -668,7 +668,7 @@
   {
     "original": ">> Go through the house to the sewers! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 通过房子，进入下水道! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -677,7 +677,7 @@
   {
     "original": ">> Go through the balcony door! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 穿过露台的门! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -686,7 +686,7 @@
   {
     "original": ">> Kill the Dragonpriest! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 杀死龙祭司! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -695,7 +695,7 @@
   {
     "original": ">> We killed the Dragonpriest! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 我们杀死了龙祭司! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -704,7 +704,7 @@
   {
     "original": ">> Hold the zombies back until the teleporter activates! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 拖住僵尸! 守到传送魔法吟唱完毕! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -713,7 +713,7 @@
   {
     "original": ">> The teleporter is working JUMP INTO IT! <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 传送阵已准备就绪! 跳下去! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -722,7 +722,7 @@
   {
     "original": ">> USE THE ELDER SCROLL NOW <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 现在快使用上古卷轴 <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -731,7 +731,7 @@
   {
     "original": "*** THE ELDER SCROLL MADE IT TO THE END ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 上古卷轴将终结这一切! ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -740,7 +740,7 @@
   {
     "original": "*** YOU CAN NOW USE IT ON NEXT STAGE ***",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "*** 你现在可以在下一幕使用它 ***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -749,7 +749,7 @@
   {
     "original": ">> You Have Defeated Alduin <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 你击败了巨龙(奥杜因) <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -758,7 +758,7 @@
   {
     "original": ">> Run for the Mead Hall <<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">> 撤退至蜜酒厅! 屠龙者们好好享受领主的款待吧! <<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -767,7 +767,7 @@
   {
     "original": "** YOU HAVE BEATEN THE MAP CONGRATULATIONS !!! **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 你们是冠军 !!! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -776,7 +776,7 @@
   {
     "original": "** MAP BY P'A'SS AND KIM !!! **",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "** 地图制作: P'A'SS AND KIM !!! && 翻译: Asuka Langley **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,


### PR DESCRIPTION
Optimized SC translation texts of Otakuroom and Rampage
Fixed countdown issues on Otakuroom ZM mode, now it is counting by seconds rather than minutes
Added the SC translation of Skyrim, Shroomforest2, and Forsaken Temple