### PR TITLE
修改ze_obf_npst_v2_legacy的部分倒计时与出错的翻译文本

### DIFF
--- a/ze/ze_obf_npst_v2_legacy.json
+++ b/ze/ze_obf_npst_v2_legacy.json
@@ -11,7 +11,7 @@
   {
     "original": "youtube.com/watch?v=vZOBj0FcHz0",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "youtube.com/watch?v=vZOBj0FcHz0",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -74,7 +74,7 @@
   {
     "original": "\u003C\u003C\u003CThe yellow door Area 9 will open in 10 seconds\u003E\u003E\u003E",
     "en_trans": "",
-    "zh_trans": "九区黄色的门将在10秒后打开",
+    "zh_trans": "九号区域的黄色大门将在10秒后打开",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 10,
@@ -92,7 +92,7 @@
   {
     "original": "\u003C\u003C\u003CThe door is opening get inside !\u003E\u003E\u003E",
     "en_trans": "",
-    "zh_trans": "门开了,进去吧",
+    "zh_trans": "门即将打开，快进去！",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -101,7 +101,7 @@
   {
     "original": "\u003C\u003C\u003CWe are not giving thanks to Kotya for scripts\u003E\u003E\u003E",
     "en_trans": "",
-    "zh_trans": "我们可没感谢Kotya的脚本",
+    "zh_trans": "感谢Kotya的脚本",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -146,7 +146,7 @@
   {
     "original": "\u003C\u003C\u003CThe door leading to the elevator are open!\u003E\u003E\u003E",
     "en_trans": "",
-    "zh_trans": "通往电梯的门开着",
+    "zh_trans": "通往电梯的门已经打开",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -164,7 +164,7 @@
   {
     "original": "\u003C\u003C\u003CAdvance before it closes !\u003E\u003E\u003E",
     "en_trans": "",
-    "zh_trans": "在火焰消失之前防守住僵尸",
+    "zh_trans": "在电梯门关上之前赶紧离开这",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -173,7 +173,7 @@
   {
     "original": "\u003C\u003C\u003CThe fence has broken\u003E\u003E\u003E",
     "en_trans": "",
-    "zh_trans": "栅栏已经被破坏了",
+    "zh_trans": "水下的栅栏网已经被破坏了",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -182,7 +182,7 @@
   {
     "original": "\u003C\u003C\u003CCall the elevator\u003E\u003E\u003E",
     "en_trans": "",
-    "zh_trans": "呼叫电梯",
+    "zh_trans": "按下按钮，等待电梯的到来",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -191,7 +191,7 @@
   {
     "original": "\u003C\u003C\u003CThe door is going to open\u003E\u003E\u003E",
     "en_trans": "",
-    "zh_trans": "门要开",
+    "zh_trans": "尸笼大门即将打开",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -209,7 +209,7 @@
   {
     "original": "\u003C\u003C\u003CWe are not giving thanks to Waffel for helping\u003E\u003E\u003E",
     "en_trans": "",
-    "zh_trans": "我们可没感谢Waffel的帮忙",
+    "zh_trans": "感谢Waffel的帮忙",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -227,7 +227,7 @@
   {
     "original": "We are not giving thanks to Friend for brushwork",
     "en_trans": "",
-    "zh_trans": "我们可没感谢我的朋友对于地图美术的贡献",
+    "zh_trans": "感谢我的朋友对地图美术的贡献",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -236,11 +236,11 @@
   {
     "original": "\u003C\u003C\u003CDOOR IS OPEN\u003E\u003E\u003E",
     "en_trans": "",
-    "zh_trans": "大门开启了",
+    "zh_trans": "大门还有<<< 23 >>>秒打开",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 23,
+    "enable_timer": 1
   },
   {
     "original": "\u003C\u003C\u003CIt\u0027s not finished\u003E\u003E\u003E",
@@ -254,7 +254,7 @@
   {
     "original": "\u003C\u003C\u003C5\u003E\u003E\u003E",
     "en_trans": "",
-    "zh_trans": "5",
+    "zh_trans": "<<< 5 >>>",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 5,
@@ -263,7 +263,7 @@
   {
     "original": "\u003C\u003C\u003C4\u003E\u003E\u003E",
     "en_trans": "",
-    "zh_trans": "4",
+    "zh_trans": "<<< 4 >>>",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 4,
@@ -272,7 +272,7 @@
   {
     "original": "\u003C\u003C\u003C3\u003E\u003E\u003E",
     "en_trans": "",
-    "zh_trans": "3",
+    "zh_trans": "<<< 3 >>>",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 3,
@@ -281,7 +281,7 @@
   {
     "original": "\u003C\u003C\u003C2\u003E\u003E\u003E",
     "en_trans": "",
-    "zh_trans": "2",
+    "zh_trans": "<<< 2 >>>",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 2,
@@ -290,7 +290,7 @@
   {
     "original": "\u003C\u003C\u003C1\u003E\u003E\u003E",
     "en_trans": "",
-    "zh_trans": "1",
+    "zh_trans": "<<< 1 >>>",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 1,
@@ -308,16 +308,16 @@
   {
     "original": "\u003C检测到泰坦离场,10秒后执行处死事件\u003E",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "检测到泰坦离开紫色区域,10秒后执行处死事件",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 10,
+    "enable_timer": 1
   },
   {
     "original": "\u003C已触发处死事件\u003E",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "已触发处死事件",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,


### PR DESCRIPTION
原翻译中存在部分 翻译错误 ，以及随着版本更新部分门提示打开但在实际上未打开的情况，故修改翻译文本。