### PR TITLE
修正ze_obf_rampage_v2_legacy.json的倒计时

### DIFF
--- a/ze/ze_obf_rampage_v2_legacy.json
+++ b/ze/ze_obf_rampage_v2_legacy.json
@@ -371,16 +371,16 @@
   {
     "original": "DEFEND 70 SECONDS",
     "en_trans": "",
-    "zh_trans": "防守<<< 70 >>>秒",
+    "zh_trans": "防守<<< 65 >>>秒",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 70,
+    "timer_num": 65,
     "enable_timer": 1
   },
   {
     "original": "Zombie triggered,we have fail.",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "僵尸破坏了电源，我们，失败了……",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,


### PR DESCRIPTION
实体问题，地图自带时间有错误，加以修正