### PR TITLE
更新之前的地图提示+修改错误翻译

### DIFF
--- a/ze/ze_alien_shooter.json
+++ b/ze/ze_alien_shooter.json
@@ -183,7 +183,7 @@
   {
     "original": ">>>Zombies inside helicopter!<<<",
     "en_trans": "",
-    "zh_trans": ">>>竟然让僵尸跟着一起上牢大，你们好亚撒西ヾ(･ω･`｡)**<<<",
+    "zh_trans": ">>>竟然想让僵尸跟着一起撤退，你们好亚撒西ヾ(･ω･`｡)**<<<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -192,7 +192,7 @@
   {
     "original": "Thank you for playing!",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "感谢你的游玩!",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -201,7 +201,7 @@
   {
     "original": ">>>Map made: DarkRoad<<<",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": ">>>地图作者: DarkRoad<<<",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,

--- a/ze/ze_aooka.json
+++ b/ze/ze_aooka.json
@@ -212,7 +212,7 @@
     "zh_trans": "< 涡旋 - 对boss按s >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -221,7 +221,7 @@
     "zh_trans": "< 火焰 - 上两边栏杆 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -230,7 +230,7 @@
     "zh_trans": "< 沙尘 - 蹲下 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -239,7 +239,7 @@
     "zh_trans": "< 空间传送 - 贴近boss但别贴死 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -365,7 +365,7 @@
     "zh_trans": "< 泥潭 - 上栏杆 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -374,16 +374,16 @@
     "zh_trans": "< 毒 - 先去中间再去外圈 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
     "original": "< Boot - Vortex >",
     "en_trans": "",
-    "zh_trans": "< 涡旋 - 抵抗中间吸力（不要站对角线上） >",
+    "zh_trans": "< 涡旋 - 抵抗中间吸力（不要站对角线上抵抗） >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -392,7 +392,7 @@
     "zh_trans": "< 雪环 - 远离特效 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -401,7 +401,7 @@
     "zh_trans": "< 星之落 - 先去外圈再去中间 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -509,7 +509,7 @@
     "zh_trans": "< 站在“金轮”的范围内以规避伤害 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 4,
     "enable_timer": 1
   },
   {
@@ -518,7 +518,7 @@
     "zh_trans": "< 黑暗之光 - 先远离光圈，等周围出现黑色特效之后再进入光圈躲避 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -527,7 +527,7 @@
     "zh_trans": "< 双生 - 前后躲避特效 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -545,7 +545,7 @@
     "zh_trans": "< 星锁 - 停枪，提前去场地中间 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 2,
     "enable_timer": 1
   },
   {
@@ -554,7 +554,7 @@
     "zh_trans": "< 星解 - 去中间规避伤害 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
+    "timer_num": 2,
     "enable_timer": 0
   },
   {
@@ -563,7 +563,7 @@
     "zh_trans": "< 死亡之星 - 远离中间 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 2,
     "enable_timer": 1
   },
   {
@@ -572,7 +572,7 @@
     "zh_trans": "< 灵魂汲取 - boss回血，提前蹲下 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 2,
     "enable_timer": 1
   },
   {
@@ -581,7 +581,7 @@
     "zh_trans": "< 电球 - 远离电球正面 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
+    "timer_num": 2,
     "enable_timer": 0
   },
   {
@@ -590,7 +590,7 @@
     "zh_trans": "< 天罪 - 蹲下 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 2,
     "enable_timer": 1
   },
   {
@@ -599,7 +599,7 @@
     "zh_trans": "< 时间之茧 - 从左上角开始按顺时针依次移动躲避四次伤害 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -608,7 +608,7 @@
     "zh_trans": "< 沙暴 - 按s抵抗 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -617,7 +617,7 @@
     "zh_trans": "< 加速蚕食 - 再次进入金轮范围规避秒杀 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 2,
     "enable_timer": 1
   },
   {
@@ -680,7 +680,7 @@
     "zh_trans": "< 火焰护盾 - 停枪并随机出现半场火场 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -689,7 +689,7 @@
     "zh_trans": "< 神圣-贴紧两边尸笼 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -698,7 +698,7 @@
     "zh_trans": "< 重力 - 抵抗吸力 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -707,7 +707,7 @@
     "zh_trans": "< 雷霆 - 去没有电球和特效的区域 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -716,7 +716,7 @@
     "zh_trans": "< 火焰治疗 - 随机出现半场火场 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -725,7 +725,7 @@
     "zh_trans": "< 飓风 - 对门口按s抵抗 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -806,7 +806,7 @@
     "zh_trans": "< 冰刃 - 躲避特效 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -815,7 +815,7 @@
     "zh_trans": "< 自我修复 - 停枪 >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -860,7 +860,7 @@
     "zh_trans": "< 终极-贴紧内侧门框（注意是内侧） >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {

--- a/ze/ze_apprehended.json
+++ b/ze/ze_apprehended.json
@@ -128,10 +128,10 @@
   {
     "original": "GET OUT OF HERE, STALKER",
     "en_trans": "",
-    "zh_trans": "你个跟踪狂，给我滚开！（秒杀伤害，远离boss）",
+    "zh_trans": "滚呐！你这个跟踪狂！（秒杀伤害，远离boss）",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {

--- a/ze/ze_beyond_the_boundary.json
+++ b/ze/ze_beyond_the_boundary.json
@@ -194,16 +194,16 @@
     "zh_trans": "有人触发了>>Normal<<模式的彩蛋，接下来去找绿精灵（不想继续触发就不要去找精灵）",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "Caught the ��Green Elf��, Difficulty ��Normal��",
     "en_trans": "",
-    "zh_trans": "已抓到 ��绿精灵��, 当前回合已变为 ��Normal��模式（回合结束重置）",
+    "zh_trans": "已抓到 ��绿精灵��, 当前回合已变为 Normal 模式（回合结束重置）",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   }
 ]

--- a/ze/ze_bluearchive_abydos_b1.json
+++ b/ze/ze_bluearchive_abydos_b1.json
@@ -302,7 +302,7 @@
     "zh_trans": "<<中间栅栏碎了!!>>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 4,
     "enable_timer": 1
   },
   {
@@ -311,7 +311,7 @@
     "zh_trans": "<<左边栅栏碎了!!>>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 4,
     "enable_timer": 1
   }
 ]

--- a/ze/ze_dnb_realms_a1.json
+++ b/ze/ze_dnb_realms_a1.json
@@ -122,7 +122,7 @@
     "zh_trans": "[第二关]工业下水道",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 2,
+    "timer_num": 1,
     "enable_timer": 1
   },
   {
@@ -131,7 +131,7 @@
     "zh_trans": "[第三关]太空入侵",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 3,
+    "timer_num": 1,
     "enable_timer": 1
   },
   {
@@ -140,7 +140,7 @@
     "zh_trans": "[第四关]时间",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 4,
+    "timer_num": 1,
     "enable_timer": 1
   },
   {

--- a/ze/ze_dreamin.json
+++ b/ze/ze_dreamin.json
@@ -149,8 +149,8 @@
     "zh_trans": "***boss使用了黑洞***",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "***Wind Casted***",
@@ -158,8 +158,8 @@
     "zh_trans": "***boss使用了风***",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "***Ice Casted***",
@@ -167,8 +167,8 @@
     "zh_trans": "***boss使用了冰***",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "***Snow picked up***",
@@ -185,8 +185,8 @@
     "zh_trans": "***boss使用了击飞***",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "***Go Back to teleport place***",
@@ -227,7 +227,7 @@
   {
     "original": "***Run!***",
     "en_trans": "",
-    "zh_trans": "***跑路了兄弟！***",
+    "zh_trans": "***撤退！***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -383,7 +383,7 @@
     "zh_trans": "***疯狂弹幕（先回头躲外圈再躲内圈）***",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -392,7 +392,7 @@
     "zh_trans": "***跳刀（四周随机来刀）***",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -401,7 +401,7 @@
     "zh_trans": "***自由落体（保证落在平台上）***",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -410,7 +410,7 @@
     "zh_trans": "***煎蛋（远离红色区域）***",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -470,10 +470,10 @@
   {
     "original": "***Reflection will cast in 2s*",
     "en_trans": "",
-    "zh_trans": "***boss即将反伤（停枪）*",
+    "zh_trans": "***反伤将在2秒后启用（停枪）*",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 2,
     "enable_timer": 1
   },
   {
@@ -482,8 +482,8 @@
     "zh_trans": "***反伤将在1秒后启用（停枪）*",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "***Reflection Casted***",

--- a/ze/ze_fall_guys.json
+++ b/ze/ze_fall_guys.json
@@ -14,7 +14,7 @@
     "zh_trans": "**目眩山巅（躲开障碍前往终点）**",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 5,
     "enable_timer": 1
   },
   {
@@ -23,7 +23,7 @@
     "zh_trans": "**旋转木马（尽快前往终点）**",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 5,
     "enable_timer": 1
   },
   {
@@ -32,7 +32,7 @@
     "zh_trans": "**障碍狂欢（避开障碍抵达终点）**",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 5,
     "enable_timer": 1
   },
   {
@@ -41,16 +41,16 @@
     "zh_trans": "**KZ（尽快前往终点）**",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 5,
     "enable_timer": 1
   },
   {
     "original": "**Fruit Race**",
     "en_trans": "",
-    "zh_trans": "**完美配对（记住头顶的图案不要掉下去）**",
+    "zh_trans": "**完美配对（记住头顶即将出现的图案不要掉下去）**",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 5,
     "enable_timer": 1
   },
   {
@@ -59,7 +59,7 @@
     "zh_trans": "*五花八门（尽快前往终点）**",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 5,
     "enable_timer": 1
   },
   {
@@ -68,7 +68,7 @@
     "zh_trans": "**蜂窝迷图（被玩家踩过的方块会碎掉）**",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 5,
     "enable_timer": 1
   },
   {
@@ -77,13 +77,13 @@
     "zh_trans": "**跳绳（保证自己在平台上）**",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 5,
     "enable_timer": 1
   },
   {
     "original": "**Zombie on elevator**",
     "en_trans": "",
-    "zh_trans": "**僵尸摸到了电梯**",
+    "zh_trans": "**我趣，僵尸要和人类一起躲天坠啦**",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -95,7 +95,7 @@
     "zh_trans": "**抬头躲天坠（躲完低头躲地坠）**",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   }
 ]

--- a/ze/ze_forhidden_void.json
+++ b/ze/ze_forhidden_void.json
@@ -32,7 +32,7 @@
     "zh_trans": "我们必须取回我们的设备，在坠机地点周围搜寻丢失的设备！（用刀划需要收集的物品）",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 4,
     "enable_timer": 1
   },
   {
@@ -338,7 +338,7 @@
     "zh_trans": "左边（面对僵尸右边是路）",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -842,7 +842,7 @@
     "zh_trans": "看起来我们得走左边",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -923,7 +923,7 @@
     "zh_trans": "看起来我们得走右边。",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -1067,7 +1067,7 @@
     "zh_trans": "右边（面对僵尸左边是路）",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -1139,7 +1139,7 @@
     "zh_trans": "寻找水晶来清除障碍（左边两个，右边两个）",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 4,
     "enable_timer": 1
   },
   {
@@ -1184,7 +1184,7 @@
     "zh_trans": "圣灵祷告[5秒后在奶神器位置释放断头奶]",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 5,
     "enable_timer": 1
   },
   {

--- a/ze/ze_forsaken_temple.json
+++ b/ze/ze_forsaken_temple.json
@@ -266,7 +266,7 @@
     "zh_trans": "** 神圣之泪 - 快蹲下 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -275,7 +275,7 @@
     "zh_trans": "** 吸血状态 - 停止射击 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -284,7 +284,7 @@
     "zh_trans": "** 弹射 - 跳起来! **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -527,7 +527,7 @@
     "zh_trans": "** 黑洞（远离特效） **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -536,7 +536,7 @@
     "zh_trans": "** 大地之力（远离脚底特效） **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -545,7 +545,7 @@
     "zh_trans": "** 下沉（站在两块平台交接处） **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -698,7 +698,7 @@
     "zh_trans": "** 舞动之爪（准备起跳） **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -707,7 +707,7 @@
     "zh_trans": "** 神圣之泪（蹲下） **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -716,7 +716,7 @@
     "zh_trans": "** 淹没一切（按s抵抗）**",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -725,7 +725,7 @@
     "zh_trans": "** 吸血状态（停枪） **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -734,7 +734,7 @@
     "zh_trans": "** 自然之力（按w抵抗） **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -788,7 +788,7 @@
     "zh_trans": "** 山崩地裂 - 避开红色平台 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -1328,8 +1328,8 @@
     "zh_trans": "** 弹射 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 3,
+    "enable_timer": 1
   },
   {
     "original": "** Thanks for playing **",

--- a/ze/ze_frozen_abyss.json
+++ b/ze/ze_frozen_abyss.json
@@ -227,7 +227,7 @@
   {
     "original": "| Admin has choosed stage 2 |",
     "en_trans": "",
-    "zh_trans": "",
+    "zh_trans": "| 管理员选择了第二关 |",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 2,
@@ -338,8 +338,8 @@
     "zh_trans": "| 深渊守护者已施放出:冰封深渊 |",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "| Stay in the middle now ! |",
@@ -347,8 +347,8 @@
     "zh_trans": "| 现在待在中间位置 |",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "** Abyss guardian has casted Ice World **",
@@ -356,17 +356,17 @@
     "zh_trans": "** 深渊守护者已施放出:冰之世界 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "** Climb the side now ! **",
     "en_trans": "",
-    "zh_trans": "** 现在爬上侧面 **",
+    "zh_trans": "** 现在去贴墙 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 3,
+    "enable_timer": 3
   },
   {
     "original": "| Abyss guardian has been defeated |",

--- a/ze/ze_halloween_house_p.json
+++ b/ze/ze_halloween_house_p.json
@@ -38,7 +38,7 @@
   {
     "original": "** THE WINDOW! GET ON IT! **",
     "en_trans": "",
-    "zh_trans": "**  窗户碎了！快走！ **",
+    "zh_trans": "** 窗户碎了！快走！ **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -59,7 +59,7 @@
     "zh_trans": "** 如果我们转动仓鼠轮上面的门就可能会打开（在轮子里对着门口按s或背对着按w） **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -92,7 +92,7 @@
   {
     "original": "** We need to reach the top! **",
     "en_trans": "",
-    "zh_trans": "** 我们得爬到桌子上面! **",
+    "zh_trans": "** 我们得爬到桌子上面看看! **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -239,7 +239,7 @@
     "zh_trans": "** 试着让这个小火车动起来！我们必须离开这里！（拉杆要拉七下，第六下的时候老鼠会被放出来） **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -338,7 +338,7 @@
     "zh_trans": "** 打计数器! 如果我们能把它打爆应该就可以通过燃气灶了（对红点中间的位置开枪） **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {

--- a/ze/ze_iceworld_athletic_cs2.json
+++ b/ze/ze_iceworld_athletic_cs2.json
@@ -77,8 +77,8 @@
     "zh_trans": "<< 英雄模式 >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "<< Shooting the crystal to become the HERO >>",
@@ -182,7 +182,7 @@
   {
     "original": "<< OHHHHHH ITS E PICK LEGEND !!! >>",
     "en_trans": "",
-    "zh_trans": "<< OHHHHHH 这是按 e 抢的传奇玩家 !!! >>",
+    "zh_trans": "<< OHHHHHH epick 高手你怎么似了! >>",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -203,8 +203,8 @@
     "zh_trans": "<< 团队模式 >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "<< zombie will come in 5 seconds >>",
@@ -221,8 +221,8 @@
     "zh_trans": "<< 死亡奔跑模式 >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "<< SOLO MODE >>",
@@ -230,8 +230,8 @@
     "zh_trans": "<< SOLO模式 >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "<< DEFENSE MODE >>",
@@ -239,8 +239,8 @@
     "zh_trans": "<< 防守模式 >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "<< BUTTON MODE >>",
@@ -248,8 +248,8 @@
     "zh_trans": "<< 按钮模式 >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "<< zombie will come in 20 seconds >>",
@@ -266,8 +266,8 @@
     "zh_trans": "<< 青蛙过河模式 >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "<< You have already win 4 mode!!! >>",

--- a/ze/ze_k19_escape_p.json
+++ b/ze/ze_k19_escape_p.json
@@ -14,8 +14,8 @@
     "zh_trans": "> 由@Seth进行CS2移植 <",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 2,
-    "enable_timer": 1
+    "timer_num": 0,
+    "enable_timer": 0
   },
   {
     "original": "***Wall will break in 20 sec***",

--- a/ze/ze_misaka.json
+++ b/ze/ze_misaka.json
@@ -32,7 +32,7 @@
     "zh_trans": "<< 推力 (按w抵抗) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -41,7 +41,7 @@
     "zh_trans": "<< 漏极 (按s抵抗) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -50,7 +50,7 @@
     "zh_trans": "<< 剑之试炼 (跳蹲刀) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -59,7 +59,7 @@
     "zh_trans": "<< 天空坠落 (看头顶躲避) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -77,16 +77,16 @@
     "zh_trans": "<< 御坂使用了超电磁炮（去两边） >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
     "original": "<< Wind >>",
     "en_trans": "",
-    "zh_trans": "<< 风之引 (反方向抵抗) >>",
+    "zh_trans": "<< 风之引 (对光球反方向抵抗) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -491,7 +491,7 @@
     "zh_trans": "<< 三段暗浪 (按w抵抗) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -500,7 +500,7 @@
     "zh_trans": "<< 绝对净化 (中间旋转刀) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -509,7 +509,7 @@
     "zh_trans": "<< 复仇之焰 (尸笼) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -518,7 +518,7 @@
     "zh_trans": "<< 死亡征兆 (头顶刀) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -527,7 +527,7 @@
     "zh_trans": "<< 狩猎本能 (跳刀) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -896,7 +896,7 @@
     "zh_trans": "<< 千兆漏极 (按s抵抗) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -905,7 +905,7 @@
     "zh_trans": "<< 收割之刃 (蹲下) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -914,7 +914,7 @@
     "zh_trans": "<< 三段推力 (按w抵抗) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -1157,8 +1157,8 @@
     "zh_trans": "<< 上下上下 !!! >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "<< defend for 15 seconds >>",

--- a/ze/ze_palace_of_minolila_cs2.json
+++ b/ze/ze_palace_of_minolila_cs2.json
@@ -329,7 +329,7 @@
     "zh_trans": "<< 推力 >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -338,7 +338,7 @@
     "zh_trans": "<< 吸力 >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -416,7 +416,7 @@
   {
     "original": "<< WTF...... Final 10 seconds!!! Hold on!!! >>",
     "en_trans": "",
-    "zh_trans": "<< 我勒个豆！！ 最后10秒!!! 坚持住!!! >>",
+    "zh_trans": "<< 我勒个豆！ 最后10秒!!! 坚持住!!! >>",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 10,
@@ -536,7 +536,7 @@
     "zh_trans": "<< X博士使用了数据删除（远离黄色区域） >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {

--- a/ze/ze_panic_escape_p.json
+++ b/ze/ze_panic_escape_p.json
@@ -2,10 +2,10 @@
   {
     "original": "***1***",
     "en_trans": "",
-    "zh_trans": "***1***",
+    "zh_trans": "***第一关（没刀，不要去逃课了）***",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 1,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -38,16 +38,16 @@
   {
     "original": "***2***",
     "en_trans": "",
-    "zh_trans": "***2***",
+    "zh_trans": "***第二关（屋内四刀）***",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 2,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
     "original": "***3***",
     "en_trans": "",
-    "zh_trans": "***3***",
+    "zh_trans": "***第三关（屋内八刀）***",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 3,

--- a/ze/ze_scp_containment_breach.json
+++ b/ze/ze_scp_containment_breach.json
@@ -221,7 +221,7 @@
     "zh_trans": "< 基石判决（远离中间） >",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -248,7 +248,7 @@
     "zh_trans": "<守住A大门（boss出现时僵尸方向会随机一刀高低刀）>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 2,
     "enable_timer": 1
   },
   {

--- a/ze/ze_sky_fantasy_v1.json
+++ b/ze/ze_sky_fantasy_v1.json
@@ -221,7 +221,7 @@
     "zh_trans": "<< 旋转刀片 (躲头顶刀) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -230,7 +230,7 @@
     "zh_trans": "<< 不祥之风 (随机方向推力) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -239,7 +239,7 @@
     "zh_trans": "<< 闪光轨道炮 (不能钻缝) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -248,7 +248,7 @@
     "zh_trans": "<< 创世之盾 (反伤停火) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -257,7 +257,7 @@
     "zh_trans": "<< 纯粹之怒 (尸笼) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -266,7 +266,7 @@
     "zh_trans": "<< 恶魔牢笼 (左右各三刀)>>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -347,7 +347,7 @@
     "zh_trans": "<< 大地之力 (站到上升的平台上) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -356,7 +356,7 @@
     "zh_trans": "<< 压力 (蹲下) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -365,7 +365,7 @@
     "zh_trans": "<< 三色水晶 (观察打碎的水晶颜色躲避对应技能) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -374,7 +374,7 @@
     "zh_trans": "<< 阴险预兆 (往边缘站) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -383,7 +383,7 @@
     "zh_trans": "<< 危险范围 (躲避脚底特效) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -392,7 +392,7 @@
     "zh_trans": "<< 极光幕 (躲避前方极光) >>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -500,7 +500,7 @@
     "zh_trans": "*** 幻想 - 大地之力 (被碰到就死) ***",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 2,
     "enable_timer": 1
   },
   {
@@ -509,7 +509,7 @@
     "zh_trans": "*** 幻想 - 火 (全屏伤害) ***",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 2,
     "enable_timer": 1
   },
   {
@@ -518,7 +518,7 @@
     "zh_trans": "*** 幻想 - 水 (全屏减速) ***",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 2,
     "enable_timer": 1
   },
   {
@@ -536,7 +536,7 @@
     "zh_trans": "*** 幻想 - 风 (随机方向推力) ***",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 2,
     "enable_timer": 1
   },
   {
@@ -545,7 +545,7 @@
     "zh_trans": "*** 幻想 - 终极 (往边缘站) ***",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 1,
     "enable_timer": 1
   },
   {
@@ -563,7 +563,7 @@
     "zh_trans": "*** 幻想 - 奇幻之星 (远离弹幕) ***",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 2,
     "enable_timer": 1
   },
   {

--- a/ze/ze_sky_fantasy_v2.json
+++ b/ze/ze_sky_fantasy_v2.json
@@ -362,7 +362,7 @@
   {
     "original": "--- Map by Misaka, Rework by K.KID ---",
     "en_trans": "",
-    "zh_trans": "--- 地图作者；Misaka, 由 K.KID 进行重置（内容补充；水木、） ---",
+    "zh_trans": "--- 地图作者；Misaka, 由 K.KID 进行重置（补充；水木、） ---",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -389,7 +389,7 @@
   {
     "original": "pressed",
     "en_trans": "",
-    "zh_trans": "pressed",
+    "zh_trans": "已按下",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -446,7 +446,7 @@
     "zh_trans": "--- 来历不明的风（随机推力） ---",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -455,7 +455,7 @@
     "zh_trans": "--- 创世之盾（停枪） ---",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -464,7 +464,7 @@
     "zh_trans": "--- 旋转刀（抬头躲刀） ---",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -473,7 +473,7 @@
     "zh_trans": "--- 纯粹之怒（尸笼） ---",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -491,7 +491,7 @@
     "zh_trans": "--- 彩虹牢笼（两侧高低刀） ---",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -500,7 +500,7 @@
     "zh_trans": "--- 轨道炮（不能钻缝） ---",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -509,16 +509,16 @@
     "zh_trans": "--- 阴险预兆 (站边缘) ---",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
     "original": "--- Aurora Veil ---",
     "en_trans": "",
-    "zh_trans": "--- 极光幕 ---",
+    "zh_trans": "--- 极光幕（躲四周光幕） ---",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -527,7 +527,7 @@
     "zh_trans": "--- 星辰陨落（抬头） ---",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -536,16 +536,16 @@
     "zh_trans": "--- 大地之力（去上升平台） ---",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
     "original": "--- Pressure ---",
     "en_trans": "",
-    "zh_trans": "--- 压力（蹲下） ---",
+    "zh_trans": "--- 压力（蹲蹲蹲蹲蹲） ---",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -563,7 +563,7 @@
     "zh_trans": "--- boss正在使用大火!!! 使用水或治疗来抵消伤害!!! ---",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 5,
     "enable_timer": 1
   },
   {
@@ -581,7 +581,7 @@
     "zh_trans": "--- 不要相信黑色刀!!（黄刀要躲黑刀要接） ---",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {

--- a/ze/ze_skygarden.json
+++ b/ze/ze_skygarden.json
@@ -338,7 +338,7 @@
     "zh_trans": "** 剧毒沼泽 - 必须前往二楼 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -356,7 +356,7 @@
     "zh_trans": "** 精力超载 - 守住僵尸 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -365,7 +365,7 @@
     "zh_trans": "** 精神扩散, 规避伤害 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -374,7 +374,7 @@
     "zh_trans": "** 毒气蔓延 - 进入圣池中的庇护所 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -383,7 +383,7 @@
     "zh_trans": "** 精神污染 - 注意能量球 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -392,7 +392,7 @@
     "zh_trans": "** 剧毒雾气 - 远离出口 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -410,13 +410,13 @@
     "zh_trans": "** 现在将核心抛进圣池 **",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
     "original": "** The core will emit energy, protect it from being polluted by the undead **",
     "en_trans": "",
-    "zh_trans": "** 核心散发的能量吸引了不死者！保护好核心，避免受到不死者的污染 **",
+    "zh_trans": "** 核心散发的能量吸引了不死者！保护好核心，避免其受到不死者的污染 **",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,

--- a/ze/ze_squid_game.json
+++ b/ze/ze_squid_game.json
@@ -2,7 +2,7 @@
   {
     "original": "<<< MAP BY =LIROY= >>>",
     "en_trans": "",
-    "zh_trans": "<<< 地图作者；=LIROY=（翻译；水木、） >>>",
+    "zh_trans": "<<< 地图作者；=LIROY=（补充；水木、） >>>",
     "jp_trans": "",
     "kr_trans": "",
     "timer_num": 0,
@@ -77,7 +77,7 @@
     "zh_trans": "boss释放了电（蹲蹲蹲蹲蹲）",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -86,7 +86,7 @@
     "zh_trans": "boss释放了风（对着boss抵抗推力）",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -95,7 +95,7 @@
     "zh_trans": "看下面（躲脚底特效）",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -104,8 +104,8 @@
     "zh_trans": "<<< 你必须解决进来的僵尸才能继续游戏! >>>",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 1,
+    "enable_timer": 1
   },
   {
     "original": "因地图特殊 暂时关闭hide功能 模型缩小",
@@ -122,7 +122,7 @@
     "zh_trans": "看上面（抬头躲天坠）",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 6,
+    "timer_num": 3,
     "enable_timer": 1
   },
   {
@@ -131,7 +131,7 @@
     "zh_trans": "boss使用了跳刀（boss方向固定低刀）",
     "jp_trans": "",
     "kr_trans": "",
-    "timer_num": 0,
-    "enable_timer": 0
+    "timer_num": 3,
+    "enable_timer": 1
   }
 ]


### PR DESCRIPTION
更新之前的地图提示（地图提醒的重要提示，boss战技能），避免之前的填写方式过多占用倒计时插件
具体为将timer_num的数字由6改至1---4之间，其余不动

修改部分地图遗漏和错误翻译